### PR TITLE
Add support for requesting with dc parameter

### DIFF
--- a/consul.js
+++ b/consul.js
@@ -56,10 +56,9 @@ class Consul {
 
   request(opts) {
     let config = this.config;
-
     return new Promise((fulfill, reject) => {
       request({
-        url: `${config.protocol}://${config.host}:${config.port}/v1/kv/${opts.key}?token=${config.token}${opts.recurse ? '&recurse' : ''}`,
+        url: `${config.protocol}://${config.host}:${config.port}/v1/kv/${opts.key}?token=${config.token}${opts.recurse ? '&recurse' : ''}${opts.dc ? '&dc=' + opts.dc : ''}`,
         method: opts.method || 'get',
         strictSSL: config.strictSSL,
         agentOptions: {

--- a/test/consul_test.js
+++ b/test/consul_test.js
@@ -77,6 +77,18 @@ describe('get', () => {
       });
     });
 
+    describe('when it is passed the option to speicfy the datacenter to query', () => {
+      it('adds "?dc=my-dc" to the request it makes', (done) => {
+        mockGet('&dc=my-dc');
+
+        consul.get('my/key', { dc: 'my-dc' })
+          .then(val => {
+            assert.equal(val.value, 'my-value');
+
+            done();
+          });
+      });
+    });
 
     it('returns the body of the response', (done) => {
       mockGet();


### PR DESCRIPTION
Hi, I'm trying to use your [concourse-consul-kv-resource](https://github.com/mdb/concourse-consul-kv-resource), but there is not a option to specify the datacenter to query and I can not check key-value of different (not default) datacenter.

This is because this package does not have a option to request with `dc` parameter.
So, I've added a option to request with dc parameter.