### PR TITLE
use axios instead of request

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   "parserOptions": {
-    "ecmaVersion": 6
+    "ecmaVersion": 2018
   },
   "env": {
     "node": true,

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -8,7 +8,9 @@ module.exports = {
   },
   globals: {
     it: true,
-    describe: true
+    describe: true,
+    beforeEach: true,
+    afterEach: true
   },
   extends: 'eslint:recommended',
   rules: {

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,32 +1,32 @@
 module.exports = {
-  "parserOptions": {
-    "ecmaVersion": 2018
+  parserOptions: {
+    ecmaVersion: 2018
   },
-  "env": {
-    "node": true,
-    "es6": true
+  env: {
+    node: true,
+    es6: true
   },
- "globals": {
-    "it": true,
-    "describe": true
+  globals: {
+    it: true,
+    describe: true
   },
-  "extends": "eslint:recommended",
-  "rules": {
-    "indent": [
-      "error",
+  extends: 'eslint:recommended',
+  rules: {
+    indent: [
+      'error',
       2
     ],
-    "linebreak-style": [
-      "error",
-      "unix"
+    'linebreak-style': [
+      'error',
+      'unix'
     ],
-    "quotes": [
-      "error",
-      "single"
+    quotes: [
+      'error',
+      'single'
     ],
-    "semi": [
-      "error",
-      "always"
+    semi: [
+      'error',
+      'always'
     ]
   }
 };

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -24,7 +24,7 @@ jobs:
       - uses: actions/setup-node@v3.5.1
         with:
           node-version-file: '.nvmrc'
-      - run: docker-compose up
+      - run: docker-compose up --detach
       - run: sleep 20
       - run: npm install
       - run: npm run test:e2e

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -6,31 +6,23 @@ on:
   push:
 
 jobs:
-  lint-and-unit-test:
+  test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3.5.1
         with:
           node-version-file: '.nvmrc'
-      - run: npm install
-      - run: npm test
-
-  local-end-to-end-test:
-    needs: lint-and-unit-test
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v3
-      - uses: actions/setup-node@v3.5.1
-        with:
-          node-version-file: '.nvmrc'
+      - run: npm ci
+      - name: Lint and run unit tests
+        run: npm test
       - run: docker-compose up --detach
-      - run: sleep 20
-      - run: npm install
-      - run: npm run test:e2e
+      - run: sleep 10
+      - name: Run e2e tests
+        run: npm run test:e2e
 
   validate-version:
-    needs: local-end-to-end-test
+    needs: test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -6,7 +6,7 @@ on:
   push:
 
 jobs:
-  test:
+  lint-and-unit-test:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
@@ -16,8 +16,18 @@ jobs:
       - run: npm install
       - run: npm test
 
+  local-end-to-end-test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3.5.1
+        with:
+          node-version-file: '.nvmrc'
+      - run: docker-compose up&
+      - run: npm run test:e2e
+
   validate-version:
-    needs: test
+    needs: local-end-to-end-test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -17,13 +17,15 @@ jobs:
       - run: npm test
 
   local-end-to-end-test:
+    needs: lint-and-unit-test
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
       - uses: actions/setup-node@v3.5.1
         with:
           node-version-file: '.nvmrc'
-      - run: docker-compose up&
+      - run: docker-compose up
+      - run: sleep 20
       - run: npm install
       - run: npm run test:e2e
 

--- a/.github/workflows/cicd.yaml
+++ b/.github/workflows/cicd.yaml
@@ -24,6 +24,7 @@ jobs:
         with:
           node-version-file: '.nvmrc'
       - run: docker-compose up&
+      - run: npm install
       - run: npm run test:e2e
 
   validate-version:

--- a/README.md
+++ b/README.md
@@ -88,9 +88,16 @@ consul.request({
 
 ## Development
 
-Install dependencies & run tests:
+Install dependencies & run unit tests:
 
 ```
 npm install
 npm test
+```
+
+Run end-to-end tests against a local Consul using [docker-compose](https://docs.docker.com/compose/):
+
+```
+docker-compose up --detach
+npm run test:e2e
 ```

--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ const consul = new Consul({
   ca: '<your-ca-cert>', // optional
   port: '8500', // optional; defaults to '8500'
   protocol: 'https', // optional; defaults to 'https'
-  strictSSL: true, // optional; defaults to true
 });
 ```
 

--- a/consul.js
+++ b/consul.js
@@ -57,24 +57,16 @@ class Consul {
   request(opts) {
     const config = this.config;
 
-    return new Promise((fulfill, reject) => {
-      axios({
-        url: `${config.protocol}://${config.host}:${config.port}/v1/kv/${opts.key}?token=${config.token}${opts.recurse ? '&recurse' : ''}${opts.dc ? '&dc=' + opts.dc : ''}`,
-        method: opts.method || 'get',
-        strictSSL: config.strictSSL,
-        agentOptions: {
-          cert: config.tlsCert,
-          key: config.tlsKey,
-          ca: config.ca
-        },
-        data: opts.body
-      })
-        .then(resp => {
-          fulfill(resp);
-        })
-        .catch(err => {
-          reject(err);
-        });
+    return axios({
+      url: `${config.protocol}://${config.host}:${config.port}/v1/kv/${opts.key}?token=${config.token}${opts.recurse ? '&recurse' : ''}${opts.dc ? '&dc=' + opts.dc : ''}`,
+      method: opts.method || 'get',
+      strictSSL: config.strictSSL,
+      agentOptions: {
+        cert: config.tlsCert,
+        key: config.tlsKey,
+        ca: config.ca
+      },
+      data: opts.body
     });
   }
 }

--- a/consul.js
+++ b/consul.js
@@ -31,17 +31,13 @@ class Consul {
     return resp.data;
   }
 
-  delete(key) {
-    return new Promise((fulfill, reject) => {
-      this.request({
-        key: key,
-        method: 'delete'
-      }).then(resp => {
-        fulfill(resp.data);
-      }, rejected => {
-        reject(rejected);
-      });
+  async delete(key) {
+    const resp = await this.request({
+      key: key,
+      method: 'delete'
     });
+
+    return resp.data;
   }
 
   request(opts) {

--- a/consul.js
+++ b/consul.js
@@ -6,7 +6,6 @@ class Consul {
     this.config = Object.assign({
       port: '8500',
       protocol: 'https',
-      strictSSL: true
     }, opts);
   }
 
@@ -47,7 +46,6 @@ class Consul {
     const requestOptions = {
       url: `${config.protocol}://${config.host}:${config.port}/v1/kv/${opts.key}?token=${config.token}${opts.recurse ? '&recurse' : ''}${opts.dc ? '&dc=' + opts.dc : ''}`,
       method: opts.method || 'get',
-      strictSSL: config.strictSSL,
       data: opts.body
     };
 

--- a/consul.js
+++ b/consul.js
@@ -21,18 +21,14 @@ class Consul {
     };
   }
 
-  set(key, value) {
-    return new Promise((fulfill, reject) => {
-      this.request({
-        key: key,
-        body: value,
-        method: 'put'
-      }).then(resp => {
-        fulfill(resp.data);
-      }, rejected => {
-        reject(rejected);
-      });
+  async set(key, value) {
+    const resp = await this.request({
+      key: key,
+      body: value,
+      method: 'put'
     });
+
+    return resp.data;
   }
 
   delete(key) {

--- a/consul.js
+++ b/consul.js
@@ -1,5 +1,3 @@
-'use strict';
-
 const axios = require('axios');
 
 class Consul {
@@ -11,20 +9,16 @@ class Consul {
     }, opts);
   }
 
-  get(key, opts) {
-    return new Promise((fulfill, reject) => {
-      this.request(Object.assign({
-        key: key
-      }, opts)).then(resp => {
-        fulfill({
-          responseStatus: resp.status,
-          responseBody: resp.data,
-          value: resp.status === 200 ? new Buffer.from(resp.data[0].Value, 'base64').toString('utf-8') : undefined
-        });
-      }, rejected => {
-        reject(rejected);
-      });
-    });
+  async get(key, opts) {
+    const resp = await this.request(Object.assign({
+      key: key
+    }, opts));
+
+    return {
+      responseStatus: resp.status,
+      responseBody: resp.data,
+      value: new Buffer.from(resp.data[0].Value, 'base64').toString('utf-8')
+    };
   }
 
   set(key, value) {

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,10 @@
+version: '3.7'
+
+services:
+  consul:
+    image: hashicorp/consul:latest
+    container_name: consul
+    restart: always
+    ports:
+      - "8500:8500"
+    command: "agent -server -bind 0.0.0.0 -client 0.0.0.0 -bootstrap-expect=1"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -8,3 +8,9 @@ services:
     ports:
       - "8500:8500"
     command: "agent -server -bind 0.0.0.0 -client 0.0.0.0 -bootstrap-expect=1"
+    healthcheck:
+      test: ["CMD", "curl", "-f", "http://localhost:8500/v1/status/leader"]
+      interval: 1m
+      timeout: 5s
+      retries: 3
+      start_period: 40s

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,15 +1,15 @@
 {
   "name": "consul-kv",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "consul-kv",
-      "version": "0.1.8",
+      "version": "0.2.0",
       "license": "MIT",
       "dependencies": {
-        "request": "2.88.2"
+        "axios": "1.2.2"
       },
       "devDependencies": {
         "eslint": "8.31.0",
@@ -133,6 +133,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -196,53 +197,39 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
-    "node_modules/asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "dependencies": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "node_modules/assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
-    "node_modules/aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-      "engines": {
-        "node": "*"
+    "node_modules/axios": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.2.tgz",
+      "integrity": "sha512-bz/J4gS2S3I7mpN/YZfGFTqhXTYzRho8Ay38w2otuuDR322KzFIWm/4W2K6gIwvWaws5n+mnb7D1lN9uD+QH6Q==",
+      "dependencies": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
       }
     },
-    "node_modules/aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+    "node_modules/axios/node_modules/form-data": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+      "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
     },
     "node_modules/balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
-    },
-    "node_modules/bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "dependencies": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "node_modules/binary-extensions": {
       "version": "2.2.0",
@@ -301,11 +288,6 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "node_modules/chalk": {
       "version": "4.1.2",
@@ -425,11 +407,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "node_modules/core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
     "node_modules/cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -442,17 +419,6 @@
       },
       "engines": {
         "node": ">= 8"
-      }
-    },
-    "node_modules/dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=0.10"
       }
     },
     "node_modules/debug": {
@@ -517,15 +483,6 @@
       },
       "engines": {
         "node": ">=6.0.0"
-      }
-    },
-    "node_modules/ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "dependencies": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
       }
     },
     "node_modules/escalade": {
@@ -725,28 +682,17 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "node_modules/extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-      "engines": [
-        "node >=0.6.0"
-      ]
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "node_modules/fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
     "node_modules/fast-levenshtein": {
       "version": "2.0.6",
@@ -831,25 +777,23 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
-    "node_modules/forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+    "node_modules/follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
       "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "dependencies": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
+        "node": ">=4.0"
       },
-      "engines": {
-        "node": ">= 0.12"
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
       }
     },
     "node_modules/fs.realpath": {
@@ -879,14 +823,6 @@
       "dev": true,
       "engines": {
         "node": "6.* || 8.* || >= 10.*"
-      }
-    },
-    "node_modules/getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "dependencies": {
-        "assert-plus": "^1.0.0"
       }
     },
     "node_modules/glob": {
@@ -942,27 +878,6 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
-    "node_modules/har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-      "deprecated": "this library is no longer supported",
-      "dependencies": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -979,20 +894,6 @@
       "dev": true,
       "bin": {
         "he": "bin/he"
-      }
-    },
-    "node_modules/http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      },
-      "engines": {
-        "node": ">=0.8",
-        "npm": ">=1.3.7"
       }
     },
     "node_modules/ignore": {
@@ -1105,11 +1006,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
     "node_modules/is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -1127,11 +1023,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
-    },
-    "node_modules/isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "node_modules/js-sdsl": {
       "version": "4.2.0",
@@ -1155,20 +1046,11 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
-    "node_modules/jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-    },
-    "node_modules/json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-    },
     "node_modules/json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "node_modules/json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -1179,21 +1061,8 @@
     "node_modules/json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "node_modules/jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "dependencies": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "node_modules/levn": {
       "version": "0.4.1",
@@ -1412,14 +1281,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-      "engines": {
-        "node": "*"
-      }
-    },
     "node_modules/once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -1515,11 +1376,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
     "node_modules/picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -1550,25 +1406,18 @@
         "node": ">= 8"
       }
     },
-    "node_modules/psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+    "node_modules/proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "node_modules/punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true,
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==",
-      "engines": {
-        "node": ">=0.6"
       }
     },
     "node_modules/queue-microtask": {
@@ -1622,37 +1471,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/mysticatea"
-      }
-    },
-    "node_modules/request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "deprecated": "request has been deprecated, see https://github.com/request/request/issues/3142",
-      "dependencies": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      },
-      "engines": {
-        "node": ">= 6"
       }
     },
     "node_modules/require-directory": {
@@ -1724,12 +1542,8 @@
     "node_modules/safe-buffer": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
-    },
-    "node_modules/safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+      "dev": true
     },
     "node_modules/serialize-javascript": {
       "version": "6.0.0",
@@ -1759,30 +1573,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "dependencies": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      },
-      "bin": {
-        "sshpk-conv": "bin/sshpk-conv",
-        "sshpk-sign": "bin/sshpk-sign",
-        "sshpk-verify": "bin/sshpk-verify"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/strip-ansi": {
@@ -1839,34 +1629,6 @@
         "node": ">=8.0"
       }
     },
-    "node_modules/tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "dependencies": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=0.8"
-      }
-    },
-    "node_modules/tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "dependencies": {
-        "safe-buffer": "^5.0.1"
-      },
-      "engines": {
-        "node": "*"
-      }
-    },
-    "node_modules/tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-    },
     "node_modules/type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -1895,30 +1657,9 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
       "dependencies": {
         "punycode": "^2.1.0"
-      }
-    },
-    "node_modules/uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA==",
-      "deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
-      "bin": {
-        "uuid": "bin/uuid"
-      }
-    },
-    "node_modules/verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "engines": [
-        "node >=0.6.0"
-      ],
-      "dependencies": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "node_modules/which": {
@@ -2180,6 +1921,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "dev": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -2224,47 +1966,38 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true
     },
-    "asn1": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
-      "integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-      "requires": {
-        "safer-buffer": "~2.1.0"
-      }
-    },
-    "assert-plus": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-      "integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
-    },
     "asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
       "integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
     },
-    "aws-sign2": {
-      "version": "0.7.0",
-      "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-      "integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
-    },
-    "aws4": {
-      "version": "1.8.0",
-      "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.8.0.tgz",
-      "integrity": "sha512-ReZxvNHIOv88FlT7rxcXIIC0fPt4KZqZbOlivyWtXLt8ESx84zd3kMC6iK5jVeS2qt+g7ftS7ye4fi06X5rtRQ=="
+    "axios": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.2.2.tgz",
+      "integrity": "sha512-bz/J4gS2S3I7mpN/YZfGFTqhXTYzRho8Ay38w2otuuDR322KzFIWm/4W2K6gIwvWaws5n+mnb7D1lN9uD+QH6Q==",
+      "requires": {
+        "follow-redirects": "^1.15.0",
+        "form-data": "^4.0.0",
+        "proxy-from-env": "^1.1.0"
+      },
+      "dependencies": {
+        "form-data": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.0.tgz",
+          "integrity": "sha512-ETEklSGi5t0QMZuiXoA/Q6vcnxcLQP5vdugSpuAyi6SVGi2clPPp+xgEhuMaHC+zGgn31Kd235W35f7Hykkaww==",
+          "requires": {
+            "asynckit": "^0.4.0",
+            "combined-stream": "^1.0.8",
+            "mime-types": "^2.1.12"
+          }
+        }
+      }
     },
     "balanced-match": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
       "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
       "dev": true
-    },
-    "bcrypt-pbkdf": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-      "integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-      "requires": {
-        "tweetnacl": "^0.14.3"
-      }
     },
     "binary-extensions": {
       "version": "2.2.0",
@@ -2308,11 +2041,6 @@
       "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-6.3.0.tgz",
       "integrity": "sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==",
       "dev": true
-    },
-    "caseless": {
-      "version": "0.12.0",
-      "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-      "integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
     },
     "chalk": {
       "version": "4.1.2",
@@ -2405,11 +2133,6 @@
       "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
       "dev": true
     },
-    "core-util-is": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-    },
     "cross-spawn": {
       "version": "7.0.3",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
@@ -2419,14 +2142,6 @@
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
-      }
-    },
-    "dashdash": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-      "integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-      "requires": {
-        "assert-plus": "^1.0.0"
       }
     },
     "debug": {
@@ -2468,15 +2183,6 @@
       "dev": true,
       "requires": {
         "esutils": "^2.0.2"
-      }
-    },
-    "ecc-jsbn": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-      "integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-      "requires": {
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.1.0"
       }
     },
     "escalade": {
@@ -2623,25 +2329,17 @@
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "dev": true
     },
-    "extend": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-      "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
-    },
-    "extsprintf": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-      "integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
-    },
     "fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
-      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="
+      "integrity": "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==",
+      "dev": true
     },
     "fast-json-stable-stringify": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.0.0.tgz",
-      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I="
+      "integrity": "sha1-1RQsDK7msRifh9OnYREGT4bIu/I=",
+      "dev": true
     },
     "fast-levenshtein": {
       "version": "2.0.6",
@@ -2708,20 +2406,10 @@
       "integrity": "sha512-5nqDSxl8nn5BSNxyR3n4I6eDmbolI6WT+QqR547RwxQapgjQBmtktdP+HTBb/a/zLsbzERTONyUB5pefh5TtjQ==",
       "dev": true
     },
-    "forever-agent": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-      "integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
-    },
-    "form-data": {
-      "version": "2.3.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
-      "integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-      "requires": {
-        "asynckit": "^0.4.0",
-        "combined-stream": "^1.0.6",
-        "mime-types": "^2.1.12"
-      }
+    "follow-redirects": {
+      "version": "1.15.2",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.2.tgz",
+      "integrity": "sha512-VQLG33o04KaQ8uYi2tVNbdrWp1QWxNNea+nmIB4EVM28v0hmP17z7aG1+wAkNzVq4KeXTq3221ye5qTJP91JwA=="
     },
     "fs.realpath": {
       "version": "1.0.0",
@@ -2741,14 +2429,6 @@
       "resolved": "https://registry.npmjs.org/get-caller-file/-/get-caller-file-2.0.5.tgz",
       "integrity": "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==",
       "dev": true
-    },
-    "getpass": {
-      "version": "0.1.7",
-      "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-      "integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-      "requires": {
-        "assert-plus": "^1.0.0"
-      }
     },
     "glob": {
       "version": "7.2.0",
@@ -2788,20 +2468,6 @@
       "integrity": "sha512-bzh50DW9kTPM00T8y4o8vQg89Di9oLJVLW/KaOGIXJWP/iqCN6WKYkbNOF04vFLJhwcpYUh9ydh/+5vpOqV4YQ==",
       "dev": true
     },
-    "har-schema": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-      "integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
-    },
-    "har-validator": {
-      "version": "5.1.3",
-      "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
-      "integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-      "requires": {
-        "ajv": "^6.5.5",
-        "har-schema": "^2.0.0"
-      }
-    },
     "has-flag": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -2813,16 +2479,6 @@
       "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
       "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
       "dev": true
-    },
-    "http-signature": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-      "integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "jsprim": "^1.2.2",
-        "sshpk": "^1.7.0"
-      }
     },
     "ignore": {
       "version": "5.2.4",
@@ -2904,11 +2560,6 @@
       "integrity": "sha512-YWnfyRwxL/+SsrWYfOpUtz5b3YD+nyfkHvjbcanzk8zgyO4ASD67uVMRt8k5bM4lLMDnXfriRhOpemw+NfT1eA==",
       "dev": true
     },
-    "is-typedarray": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-      "integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
-    },
     "is-unicode-supported": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-unicode-supported/-/is-unicode-supported-0.1.0.tgz",
@@ -2920,11 +2571,6 @@
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
       "dev": true
-    },
-    "isstream": {
-      "version": "0.1.2",
-      "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-      "integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
     },
     "js-sdsl": {
       "version": "4.2.0",
@@ -2941,20 +2587,11 @@
         "argparse": "^2.0.1"
       }
     },
-    "jsbn": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-      "integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
-    },
-    "json-schema": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-      "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA=="
-    },
     "json-schema-traverse": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+      "integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+      "dev": true
     },
     "json-stable-stringify-without-jsonify": {
       "version": "1.0.1",
@@ -2965,18 +2602,8 @@
     "json-stringify-safe": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
-    },
-    "jsprim": {
-      "version": "1.4.2",
-      "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-      "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-      "requires": {
-        "assert-plus": "1.0.0",
-        "extsprintf": "1.3.0",
-        "json-schema": "0.4.0",
-        "verror": "1.10.0"
-      }
+      "integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+      "dev": true
     },
     "levn": {
       "version": "0.4.1",
@@ -3141,11 +2768,6 @@
       "integrity": "sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==",
       "dev": true
     },
-    "oauth-sign": {
-      "version": "0.9.0",
-      "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-      "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
-    },
     "once": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
@@ -3214,11 +2836,6 @@
       "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
       "dev": true
     },
-    "performance-now": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-      "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
     "picomatch": {
       "version": "2.3.1",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.1.tgz",
@@ -3237,20 +2854,16 @@
       "integrity": "sha512-vGrhOavPSTz4QVNuBNdcNXePNdNMaO1xj9yBeH1ScQPjk/rhg9sSlCXPhMkFuaNNW/syTvYqsnbIJxMBfRbbag==",
       "dev": true
     },
-    "psl": {
-      "version": "1.9.0",
-      "resolved": "https://registry.npmjs.org/psl/-/psl-1.9.0.tgz",
-      "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
+    "proxy-from-env": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
+      "integrity": "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="
     },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-    },
-    "qs": {
-      "version": "6.5.3",
-      "resolved": "https://registry.npmjs.org/qs/-/qs-6.5.3.tgz",
-      "integrity": "sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA=="
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "dev": true
     },
     "queue-microtask": {
       "version": "1.2.3",
@@ -3281,33 +2894,6 @@
       "resolved": "https://registry.npmjs.org/regexpp/-/regexpp-3.2.0.tgz",
       "integrity": "sha512-pq2bWo9mVD43nbts2wGv17XLiNLya+GklZ8kaDLV2Z08gDCsGpnKn9BFMepvWuHCbyVvY7J5o5+BVvoQbmlJLg==",
       "dev": true
-    },
-    "request": {
-      "version": "2.88.2",
-      "resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
-      "integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-      "requires": {
-        "aws-sign2": "~0.7.0",
-        "aws4": "^1.8.0",
-        "caseless": "~0.12.0",
-        "combined-stream": "~1.0.6",
-        "extend": "~3.0.2",
-        "forever-agent": "~0.6.1",
-        "form-data": "~2.3.2",
-        "har-validator": "~5.1.3",
-        "http-signature": "~1.2.0",
-        "is-typedarray": "~1.0.0",
-        "isstream": "~0.1.2",
-        "json-stringify-safe": "~5.0.1",
-        "mime-types": "~2.1.19",
-        "oauth-sign": "~0.9.0",
-        "performance-now": "^2.1.0",
-        "qs": "~6.5.2",
-        "safe-buffer": "^5.1.2",
-        "tough-cookie": "~2.5.0",
-        "tunnel-agent": "^0.6.0",
-        "uuid": "^3.3.2"
-      }
     },
     "require-directory": {
       "version": "2.1.1",
@@ -3348,12 +2934,8 @@
     "safe-buffer": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
-    },
-    "safer-buffer": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+      "integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+      "dev": true
     },
     "serialize-javascript": {
       "version": "6.0.0",
@@ -3378,22 +2960,6 @@
       "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
       "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
       "dev": true
-    },
-    "sshpk": {
-      "version": "1.16.1",
-      "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
-      "integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-      "requires": {
-        "asn1": "~0.2.3",
-        "assert-plus": "^1.0.0",
-        "bcrypt-pbkdf": "^1.0.0",
-        "dashdash": "^1.12.0",
-        "ecc-jsbn": "~0.1.1",
-        "getpass": "^0.1.1",
-        "jsbn": "~0.1.0",
-        "safer-buffer": "^2.0.2",
-        "tweetnacl": "~0.14.0"
-      }
     },
     "strip-ansi": {
       "version": "6.0.1",
@@ -3434,28 +3000,6 @@
         "is-number": "^7.0.0"
       }
     },
-    "tough-cookie": {
-      "version": "2.5.0",
-      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-      "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-      "requires": {
-        "psl": "^1.1.28",
-        "punycode": "^2.1.1"
-      }
-    },
-    "tunnel-agent": {
-      "version": "0.6.0",
-      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
-      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-      "requires": {
-        "safe-buffer": "^5.0.1"
-      }
-    },
-    "tweetnacl": {
-      "version": "0.14.5",
-      "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-      "integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
-    },
     "type-check": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.4.0.tgz",
@@ -3475,23 +3019,9 @@
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
       "integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+      "dev": true,
       "requires": {
         "punycode": "^2.1.0"
-      }
-    },
-    "uuid": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-      "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-    },
-    "verror": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-      "integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-      "requires": {
-        "assert-plus": "^1.0.0",
-        "core-util-is": "1.0.2",
-        "extsprintf": "^1.2.0"
       }
     },
     "which": {

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "A micro library to get, set, and delete Consul K/V",
   "main": "consul.js",
   "scripts": {
-    "test": "mocha && eslint *.js test/*.js"
+    "test": "mocha --recursive test/unit --exit && eslint *.js test/*.js",
+    "test:e2e": "mocha --recursive test/e2e"
   },
   "author": "Mike Ball",
   "license": "MIT",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "consul-kv",
-  "version": "0.1.8",
+  "version": "0.2.0",
   "description": "A micro library to get, set, and delete Consul K/V",
   "main": "consul.js",
   "scripts": {
@@ -9,7 +9,7 @@
   "author": "Mike Ball",
   "license": "MIT",
   "dependencies": {
-    "request": "2.88.2"
+    "axios": "1.2.2"
   },
   "devDependencies": {
     "eslint": "8.31.0",

--- a/test/consul_test.js
+++ b/test/consul_test.js
@@ -95,7 +95,7 @@ describe('get', () => {
 
       consul.get('my/key')
         .then(val => {
-          assert.equal(JSON.parse(val.responseBody)[0].Value, 'bXktdmFsdWU=');
+          assert.equal(val.responseBody[0].Value, 'bXktdmFsdWU=');
 
           done();
         });
@@ -103,12 +103,12 @@ describe('get', () => {
   });
 
   describe('when it 404s', () => {
-    it('reports the value as undefined', (done) => {
+    it('throws an error', (done) => {
       mockGet404();
 
       consul.get('my/key')
-        .then(val => {
-          assert.equal(val.value, undefined);
+        .catch(err => {
+          assert.equal(err.code, 'ERR_BAD_REQUEST');
 
           done();
         });
@@ -122,7 +122,7 @@ describe('set', () => {
 
     consul.set('my/key', 'my-value')
       .then(result => {
-        assert.equal(result, 'true');
+        assert.equal(result, true);
 
         done();
       });
@@ -135,7 +135,7 @@ describe('delete', () => {
 
     consul.delete('my/key')
       .then(result => {
-        assert.equal(result, 'true');
+        assert.equal(result, true);
 
         done();
       });

--- a/test/e2e/consul_e2e_test.js
+++ b/test/e2e/consul_e2e_test.js
@@ -1,0 +1,81 @@
+const assert = require('assert');
+const Consul = require('../../consul');
+const consul = new Consul({
+  host: 'localhost',
+  protocol: 'http'
+});
+
+describe('set', () => {
+  it('sets the key/value it is passed', (done) => {
+    consul.set('my/key', 'my-value')
+      .then(result => {
+        assert.equal(result, true);
+
+        done();
+      });
+  });
+});
+
+describe('get', () => {
+  describe('when it 200s', () => {
+    it('returns the decoded value for the key it is passed', (done) => {
+      consul.get('my/key')
+        .then(val => {
+          assert.equal(val.value, 'my-value');
+
+          done();
+        });
+    });
+
+    it('returns the status code of the response', (done) => {
+      consul.get('my/key')
+        .then(val => {
+          assert.equal(val.responseStatus, 200);
+
+          done();
+        });
+    });
+
+    describe('when it is passed the option to recursively return the entire subtree', () => {
+      it('adds "?recurse" to the request it makes', (done) => {
+        consul.get('my/key', { recurse: true })
+          .then(val => {
+            assert.equal(val.value, 'my-value');
+
+            done();
+          });
+      });
+    });
+
+    it('returns the body of the response', (done) => {
+      consul.get('my/key')
+        .then(val => {
+          assert.equal(val.responseBody[0].Value, 'bXktdmFsdWU=');
+
+          done();
+        });
+    });
+  });
+
+  describe('when it 404s', () => {
+    it('throws an error', (done) => {
+      consul.get('my/foo')
+        .catch(err => {
+          assert.equal(err.code, 'ERR_BAD_REQUEST');
+
+          done();
+        });
+    });
+  });
+});
+
+describe('delete', () => {
+  it('deletes the key/value it is passed', (done) => {
+    consul.delete('my/key')
+      .then(result => {
+        assert.equal(result, true);
+
+        done();
+      });
+  });
+});

--- a/test/e2e/consul_e2e_test.js
+++ b/test/e2e/consul_e2e_test.js
@@ -6,76 +6,131 @@ const consul = new Consul({
 });
 
 describe('set', () => {
-  it('sets the key/value it is passed', (done) => {
-    consul.set('my/key', 'my-value')
-      .then(result => {
-        assert.equal(result, true);
+  describe('when Consul responses with an HTTP 200', () => {
+    let result;
+    let err;
 
-        done();
-      });
+    beforeEach(async () => {
+      try {
+        result = await consul.set('my/key', 'my-value');
+      } catch(e) {
+        err = e;
+      }
+    });
+
+    afterEach(() => {
+      result = undefined;
+      err = undefined;
+    });
+
+    it('does not error', () => {
+      assert.equal(err, undefined);
+    });
+
+    it('sets the key/value it is passed', () => {
+      assert.equal(result, true);
+    });
   });
 });
 
 describe('get', () => {
-  describe('when it 200s', () => {
-    it('returns the decoded value for the key it is passed', (done) => {
-      consul.get('my/key')
-        .then(val => {
-          assert.equal(val.value, 'my-value');
+  describe('when Consul responses with an HTTP 200', () => {
+    let val;
+    let err;
 
-          done();
-        });
+    beforeEach(async () => {
+      try {
+        val = await consul.get('my/key');
+      } catch(e) {
+        err = e;
+      }
     });
 
-    it('returns the status code of the response', (done) => {
-      consul.get('my/key')
-        .then(val => {
-          assert.equal(val.responseStatus, 200);
+    afterEach(() => {
+      val = undefined;
+      err = undefined;
+    });
 
-          done();
-        });
+    it('does not error', () => {
+      assert.equal(err, undefined);
+    });
+
+    it('returns the decoded value for the key it is passed', () => {
+      assert.equal(val.value, 'my-value');
+    });
+
+    it('returns the status code of the response', () => {
+      assert.equal(val.responseStatus, 200);
+    });
+
+    it('returns the body of the response', () => {
+      assert.equal(val.responseBody[0].Value, 'bXktdmFsdWU=');
     });
 
     describe('when it is passed the option to recursively return the entire subtree', () => {
-      it('adds "?recurse" to the request it makes', (done) => {
-        consul.get('my/key', { recurse: true })
-          .then(val => {
-            assert.equal(val.value, 'my-value');
-
-            done();
-          });
+      beforeEach(async () => {
+        try {
+          val = await consul.get('my/key', { recurse: true });
+        } catch(e) {
+          err = e;
+        }
       });
-    });
 
-    it('returns the body of the response', (done) => {
-      consul.get('my/key')
-        .then(val => {
-          assert.equal(val.responseBody[0].Value, 'bXktdmFsdWU=');
+      it('does not error', () => {
+        assert.equal(err, undefined);
+      });
 
-          done();
-        });
+      it('adds "?recurse" to the request it makes and returns the decoded value for the specified key', () => {
+        assert.equal(val.value, 'my-value');
+      });
     });
   });
 
-  describe('when it 404s', () => {
-    it('throws an error', (done) => {
-      consul.get('my/foo')
-        .catch(err => {
-          assert.equal(err.code, 'ERR_BAD_REQUEST');
+  describe('when Consul responses with an HTTP 404', () => {
+    let err;
 
-          done();
-        });
+    beforeEach(async () => {
+      try {
+        await consul.get('my/nonexistent-key');
+      } catch(e) {
+        err = e;
+      }
+    });
+
+    afterEach(() => {
+      err = undefined;
+    });
+
+    it('throws an error', () => {
+      assert.equal(err.code, 'ERR_BAD_REQUEST');
     });
   });
 });
 
 describe('delete', () => {
-  it('deletes the key/value it is passed', (done) => {
-    consul.delete('my/key')
-      .then(result => {
-        assert.equal(result, true);
+  describe('when Consul responses with an HTTP 200', () => {
+    let result;
+    let err;
 
-        done();
-      });
+    beforeEach(async () => {
+      try {
+        result = await consul.delete('my/key');
+      } catch(e) {
+        err = e;
+      }
+    });
+
+    afterEach(() => {
+      result = undefined;
+      err = undefined;
+    });
+
+    it('does not error', () => {
+      assert.equal(err, undefined);
+    });
+
+    it('deletes the key/value it is passed', () => {
+      assert.equal(result, true);
+    });
   });
 });

--- a/test/unit/consul_test.js
+++ b/test/unit/consul_test.js
@@ -1,0 +1,143 @@
+const assert = require('assert');
+const nock = require('nock');
+const Consul = require('../../consul');
+const consulHost = 'my-consul.com';
+const consul = new Consul({
+  host: consulHost,
+  token: 'my-token',
+  tlsCert: 'cert',
+  tlsKey: 'key'
+});
+
+const host = `https://${consulHost}:8500`;
+const endpoint = '/v1/kv/my/key?token=my-token';
+
+function mockGet(query) {
+  const url = query ? `${endpoint}${query}` : endpoint;
+
+  return nock(host)
+    .get(url)
+    .reply(200, [{
+      Value: 'bXktdmFsdWU='
+    }]);
+}
+
+function mockGet404() {
+  return nock(host)
+    .get(endpoint)
+    .reply(404, []);
+}
+
+function mockPut() {
+  return nock(host)
+    .put(endpoint, 'my-value')
+    .reply(200, 'true');
+}
+
+function mockDelete() {
+  return nock(host)
+    .delete(endpoint)
+    .reply(200, 'true');
+}
+
+describe('get', () => {
+  describe('when it 200s', () => {
+    it('returns the decoded value for the key it is passed', (done) => {
+      mockGet();
+
+      consul.get('my/key')
+        .then(val => {
+          assert.equal(val.value, 'my-value');
+
+          done();
+        });
+    });
+
+    it('returns the status code of the response', (done) => {
+      mockGet();
+
+      consul.get('my/key')
+        .then(val => {
+          assert.equal(val.responseStatus, 200);
+
+          done();
+        });
+    });
+
+    describe('when it is passed the option to recursively return the entire subtree', () => {
+      it('adds "?recurse" to the request it makes', (done) => {
+        mockGet('&recurse');
+
+        consul.get('my/key', { recurse: true })
+          .then(val => {
+            assert.equal(val.value, 'my-value');
+
+            done();
+          });
+      });
+    });
+
+    describe('when it is passed the option to speicfy the datacenter to query', () => {
+      it('adds "?dc=my-dc" to the request it makes', (done) => {
+        mockGet('&dc=my-dc');
+
+        consul.get('my/key', { dc: 'my-dc' })
+          .then(val => {
+            assert.equal(val.value, 'my-value');
+
+            done();
+          });
+      });
+    });
+
+    it('returns the body of the response', (done) => {
+      mockGet();
+
+      consul.get('my/key')
+        .then(val => {
+          assert.equal(val.responseBody[0].Value, 'bXktdmFsdWU=');
+
+          done();
+        });
+    });
+  });
+
+  describe('when it 404s', () => {
+    it('throws an error', (done) => {
+      mockGet404();
+
+      consul.get('my/key')
+        .catch(err => {
+          assert.equal(err.code, 'ERR_BAD_REQUEST');
+
+          done();
+        });
+    });
+  });
+});
+
+describe('set', () => {
+  it('sets the key/value it is passed', (done) => {
+    mockPut();
+
+    consul.set('my/key', 'my-value')
+      .then(result => {
+        assert.equal(result, true);
+
+        done();
+      });
+  });
+});
+
+describe('delete', () => {
+  it('deletes the key/value it is passed', (done) => {
+    mockDelete();
+
+    consul.delete('my/key')
+      .then(result => {
+        assert.equal(result, true);
+
+        done();
+      });
+  });
+});

--- a/test/unit/consul_test.js
+++ b/test/unit/consul_test.js
@@ -41,103 +41,161 @@ function mockDelete() {
 }
 
 describe('get', () => {
-  describe('when it 200s', () => {
-    it('returns the decoded value for the key it is passed', (done) => {
+  describe('when Consul responses with an HTTP 200', () => {
+    let val;
+    let err;
+
+    beforeEach(async () => {
       mockGet();
 
-      consul.get('my/key')
-        .then(val => {
-          assert.equal(val.value, 'my-value');
-
-          done();
-        });
+      try {
+        val = await consul.get('my/key');
+      } catch(e) {
+        err = e;
+      }
     });
 
-    it('returns the status code of the response', (done) => {
-      mockGet();
+    afterEach(() => {
+      val = undefined;
+      err = undefined;
+    });
 
-      consul.get('my/key')
-        .then(val => {
-          assert.equal(val.responseStatus, 200);
+    it('does not error', () => {
+      assert.equal(err, undefined);
+    });
 
-          done();
-        });
+    it('returns the decoded value for the key it is passed', () => {
+      assert.equal(val.value, 'my-value');
+    });
+
+    it('returns the status code of the response', () => {
+      assert.equal(val.responseStatus, 200);
+    });
+
+    it('returns the body of the response', () => {
+      assert.equal(val.responseBody[0].Value, 'bXktdmFsdWU=');
     });
 
     describe('when it is passed the option to recursively return the entire subtree', () => {
-      it('adds "?recurse" to the request it makes', (done) => {
+      beforeEach(async () => {
         mockGet('&recurse');
 
-        consul.get('my/key', { recurse: true })
-          .then(val => {
-            assert.equal(val.value, 'my-value');
+        try {
+          val = await consul.get('my/key', { recurse: true });
+        } catch(e) {
+          err = e;
+        }
+      });
 
-            done();
-          });
+      it('does not error', () => {
+        assert.equal(err, undefined);
+      });
+
+      it('adds "?recurse" to the request it makes and returns the decoded value for the specified key', () => {
+        assert.equal(val.value, 'my-value');
       });
     });
 
     describe('when it is passed an option specifying the specific datacenter to query', () => {
-      it('adds "?dc=my-dc" to the request it makes', (done) => {
+      beforeEach(async () => {
         mockGet('&dc=my-dc');
 
-        consul.get('my/key', { dc: 'my-dc' })
-          .then(val => {
-            assert.equal(val.value, 'my-value');
-
-            done();
-          });
+        try {
+          val = await consul.get('my/key', { dc: 'my-dc' });
+        } catch(e) {
+          err = e;
+        }
       });
-    });
 
-    it('returns the body of the response', (done) => {
-      mockGet();
+      it('does not error', () => {
+        assert.equal(err, undefined);
+      });
 
-      consul.get('my/key')
-        .then(val => {
-          assert.equal(val.responseBody[0].Value, 'bXktdmFsdWU=');
-
-          done();
-        });
+      it('adds "?dc=my-dc" to the request it makes and returns the decoded value of the specified key', () => {
+        assert.equal(val.value, 'my-value');
+      });
     });
   });
 
-  describe('when it 404s', () => {
-    it('throws an error', (done) => {
+  describe('when Consul responses with an HTTP 404', () => {
+    let err;
+
+    beforeEach(async () => {
       mockGet404();
 
-      consul.get('my/key')
-        .catch(err => {
-          assert.equal(err.code, 'ERR_BAD_REQUEST');
+      try {
+        await consul.get('my/key');
+      } catch(e) {
+        err = e;
+      }
+    });
 
-          done();
-        });
+    afterEach(() => {
+      err = undefined;
+    });
+
+    it('throws an error', () => {
+      assert.equal(err.code, 'ERR_BAD_REQUEST');
     });
   });
 });
 
 describe('set', () => {
-  it('sets the key/value it is passed', (done) => {
-    mockPut();
+  describe('when Consul responses with an HTTP 200', () => {
+    let result;
+    let err;
 
-    consul.set('my/key', 'my-value')
-      .then(result => {
-        assert.equal(result, true);
+    beforeEach(async () => {
+      mockPut();
 
-        done();
-      });
+      try {
+        result = await consul.set('my/key', 'my-value');
+      } catch(e) {
+        err = e;
+      }
+    });
+
+    afterEach(() => {
+      result = undefined;
+      err = undefined;
+    });
+
+    it('does not error', () => {
+      assert.equal(err, undefined);
+    });
+
+    it('sets the key/value it is passed', () => {
+      assert.equal(result, true);
+    });
   });
 });
 
 describe('delete', () => {
-  it('deletes the key/value it is passed', (done) => {
-    mockDelete();
+  describe('when Consul responses with an HTTP 200', () => {
+    let result;
+    let err;
 
-    consul.delete('my/key')
-      .then(result => {
-        assert.equal(result, true);
+    beforeEach(async () => {
+      mockDelete();
 
-        done();
-      });
+      try {
+        result = await consul.delete('my/key');
+      } catch(e) {
+        err = e;
+      }
+    });
+
+    afterEach(() => {
+      result = undefined;
+      err = undefined;
+    });
+
+    it('does not error', () => {
+      assert.equal(err, undefined);
+    });
+
+    it('deletes the key/value it is passed', () => {
+      assert.equal(result, true);
+    });
   });
 });

--- a/test/unit/consul_test.js
+++ b/test/unit/consul_test.js
@@ -77,7 +77,7 @@ describe('get', () => {
       });
     });
 
-    describe('when it is passed the option to speicfy the datacenter to query', () => {
+    describe('when it is passed an option specifying the specific datacenter to query', () => {
       it('adds "?dc=my-dc" to the request it makes', (done) => {
         mockGet('&dc=my-dc');
 


### PR DESCRIPTION
* replaces the use of `request` with `axios`, given that `request` is deprecated
* adds e2e tests addressing issue #11 (and adds the ability to run a local, `docker-compose`'d Consul server
* improves unit test robustness
* removes `strictSSL` configuration option
